### PR TITLE
Update Node.js to 10.16.3, Yarn to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ LABEL maintainer="Palmabit S.r.l. <hello@palmabit.com>"
 
 # Install node with npm and yarn
 RUN apk add --no-cache --repository http://nl.alpinelinux.org/alpine/edge/main libuv \
-    && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main nodejs=10.16.0-r0 npm=10.16.0-r0 \
-    && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community yarn=1.17.3-r0 \
+    && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main nodejs=10.16.3-r0 npm=10.16.3-r0 \
+    && apk add --no-cache --update-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community yarn=1.19.1-r0 \
     && echo "NodeJS Version:" "$(node -v)" \
     && echo "NPM Version:" "$(npm -v)" \
     && echo "Yarn Version:" "$(yarn -v)"

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Latest version:
 
 Item | Version
 ------- | -----
-Node | v10.16.0
+Node | v10.16.3
 Npm | v6.9.0
-Yarn | v1.17.3
+Yarn | v1.19.1
 Nginx | v1.17
 
 ## Supported tags
-* `10.16.0`, `latest` [(Dockerfile)](./Dockerfile)
+* `10.16.3`, `latest` [(Dockerfile)](./Dockerfile)
+* `10.16.0` [(Dockerfile)](https://github.com/Palmabit-IT/alpine-yarn-nginx/blob/10.16.0/Dockerfile)
 * `8.11.4` [(Dockerfile)](https://github.com/Palmabit-IT/alpine-yarn-nginx/blob/8.11.4/Dockerfile)
 * `8.9.4` [(Dockerfile)](https://github.com/Palmabit-IT/alpine-yarn-nginx/blob/8.9.4/Dockerfile)
 * `7.9.4` [(Dockerfile)](https://github.com/Palmabit-IT/alpine-yarn-nginx/blob/7.9.4/Dockerfile)


### PR DESCRIPTION
Aggiornato Node.js alla versione 10.16.3, Yarn alla 1.19.1.